### PR TITLE
Set correct zero-space-non-braking space

### DIFF
--- a/src/core/wrappedrange.js
+++ b/src/core/wrappedrange.js
@@ -487,7 +487,7 @@
 
             // Making the working element non-empty element persuades IE to consider the TextRange boundary to be within
             // the element rather than immediately before or after it
-            workingNode.innerHTML = "&#feff;";
+            workingNode.innerHTML = String.fromCharCode(0xfeff);
 
             // insertBefore is supposed to work like appendChild if the second parameter is null. However, a bug report
             // for IERange suggests that it can crash the browser: http://code.google.com/p/ierange/issues/detail?id=12


### PR DESCRIPTION
The code that tries to set a zero-space-non-braking space doesn't work as intended.

'workingNode.innerHTML = "&#feff;";' works differently in different browsers:
Chrome: parses the string a escapes the ampersand.
IE: fails with a 'XML5608' syntax error (see https://msdn.microsoft.com/en-us/library/dn423949(v=vs.85).aspx).

Corrected to use the correct 'String.fromCharCode(0xfeff)'.